### PR TITLE
Created follow model

### DIFF
--- a/app/models/follow.rb
+++ b/app/models/follow.rb
@@ -1,0 +1,5 @@
+class Follow < ApplicationRecord
+  belongs_to :follower, class_name: "User", foreign_key: "follower_id"
+  belongs_to :followed, class_name: "User", foreign_key: "followed_id"
+
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,8 +3,20 @@ class User < ApplicationRecord
   has_one_attached :profile_picture
   has_many :likes
   has_many :comments
+
+  has_many :follow_requests, -> { where(accepted: false) }, class_name: 'Follow', foreign_key: 'followed_id'
+  has_many :accepted_recieved_requests, -> { where(accepted: true) }, class_name: 'Follow', foreign_key: 'followed_id'
+  has_many :accepted_sent_requests, -> { where(accepted: true) }, class_name: 'Follow', foreign_key: 'follower_id'
+
+  has_many :followers, through: :accepted_recieved_requests, source: :follower
+  has_many :followings, through: :accepted_sent_requests, source: :followed
+  # has_many :recieved_requests, class_name: "Follow", foreign_key: "followed_id"
+  # has_many :set_requests, class_name: "Follow", foreign_key: "follower_id"
+
+  # has_many :waiting_sent_requests, -> { where(accepted: false) }, class_name: "Follow", foreign_key: "follower_id"
+
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
-          :recoverable, :rememberable, :validatable
+         :recoverable, :rememberable, :validatable
 end

--- a/db/migrate/20240323010744_create_follows.rb
+++ b/db/migrate/20240323010744_create_follows.rb
@@ -1,0 +1,15 @@
+class CreateFollows < ActiveRecord::Migration[7.0]
+  def change
+    create_table :follows do |t|
+      t.integer :follower_id
+      t.integer :followed_id
+      t.boolean :accepted, default: false
+
+      t.timestamps
+    end
+
+    add_index :follows, :follower_id
+    add_index :follows, :followed_id
+    add_index :follows, [:follower_id, :followed_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_03_04_040313) do
+ActiveRecord::Schema[7.0].define(version: 2024_03_23_010744) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -47,6 +47,17 @@ ActiveRecord::Schema[7.0].define(version: 2024_03_04_040313) do
     t.datetime "updated_at", null: false
     t.index ["post_id"], name: "index_comments_on_post_id"
     t.index ["user_id"], name: "index_comments_on_user_id"
+  end
+
+  create_table "follows", force: :cascade do |t|
+    t.integer "follower_id"
+    t.integer "followed_id"
+    t.boolean "accepted", default: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["followed_id"], name: "index_follows_on_followed_id"
+    t.index ["follower_id", "followed_id"], name: "index_follows_on_follower_id_and_followed_id", unique: true
+    t.index ["follower_id"], name: "index_follows_on_follower_id"
   end
 
   create_table "likes", force: :cascade do |t|

--- a/test/fixtures/follows.yml
+++ b/test/fixtures/follows.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  follower_id: 1
+  followed_id: 1
+  accepted: false
+
+two:
+  follower_id: 1
+  followed_id: 1
+  accepted: false

--- a/test/models/follow_test.rb
+++ b/test/models/follow_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class FollowTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
Created a follow model that has both a follower_id and a followed_id.

An instance of a follow belongs to a follower and followed instance referenced by the follower and followed id in the user table.

In the User model we add validations to access accepted and waiting follow requests by using the accepted boolean within the follow table. 

By referencing the follower and following id's within the follow table we can differentiate between if a follow is from the current user or to the current user.  

Lastly we can access a users followers and following accounts by the relationship sert by User.followers and User.following.