### PR TITLE
Added follow state controls to post liker modal and comments modal

### DIFF
--- a/app/views/layouts/shared/_followed_state.html.erb
+++ b/app/views/layouts/shared/_followed_state.html.erb
@@ -1,8 +1,8 @@
 <% if current_user.followings.include?(user) %>
-  <%= button_to "Unfollow", unfollow_path(user_id: user.id), method: :delete, class: 'btn btn-danger' %>
+  <%= button_to "Unfollow", unfollow_path(user_id: user.id), method: :delete, class: 'btn btn-danger', data: {turbo: "false"} %>
 <% elsif current_user.waiting_followings.include?(user)%>
-  <%= button_to "Cancel", cancel_request_path(user_id: user.id), method: :delete, class: "btn btn-secondary" %>
+  <%= button_to "Cancel", cancel_request_path(user_id: user.id), method: :delete, class: "btn btn-secondary", data: {turbo: "false"} %>
 <% elsif current_user == user %>
 <% else %>
-  <%= button_to "Follow", follow_path(user_id: user.id), method: :post, class: "btn btn-primary" %>
+  <%= button_to "Follow", follow_path(user_id: user.id), method: :post, class: "btn btn-primary", data: {turbo: "false"} %>
 <% end %>

--- a/app/views/posts/_liker.html.erb
+++ b/app/views/posts/_liker.html.erb
@@ -6,10 +6,8 @@
       <%= image_tag "default_avatar.png", class: "rounded-circle", style: "width:3rem; height:3rem;" %>
     <% end %>
     <div class="d-flex flex-column mx-2 justify-content-center">
-      <small class="fw-bold" style="overflow:hidden; white-space: nowrap; text-overflow: ellipsis;max-width:10rem"><%= link_to liker, class: "a-decoration-none", data: {turbo_frame: "_top"} do %><%= liker.username %><% end %></small>
+      <small class="fw-bold" style="overflow:hidden; white-space: nowrap; text-overflow: ellipsis;max-width:10rem"><%= link_to liker, class: "a-decoration-none", data: {turbo: false} do %><%= liker.username %><% end %></small>
     </div>
   </div>
-  <%= link_to root_path, style: "text-decoration:none;height: 10%;", class: "btn btn-primary" do %>
-    <small class="fw-bold text-white">Follow</small>
-  <% end %>
+  <%= render 'layouts/shared/followed_state', user: liker %>
 </div>

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -65,7 +65,7 @@
     <%= form_with url: comments_path, method: :post, data: {controller: "comment", action: "turbo:submit-end->comment#clear"} do |f| %>
       <div class="card-footer d-flex justify-content-between bg-white">
         <%= f.hidden_field :post_id, value: post.id %>
-        <%= f.text_area :comment_body, class: "w-75", placeholder: "Add a comment...", style: "border:none" %>
+        <%= f.text_field :comment_body, class: "w-75", placeholder: "Add a comment...", style: "border:none" %>
         <%= f.submit "Post", class: "text-primary fw-bold", style: "background:none; border:none;" %>
       </div>
     <% end %>

--- a/app/views/posts/_post_comments.html.erb
+++ b/app/views/posts/_post_comments.html.erb
@@ -6,7 +6,7 @@
     </a>
   <% end %>
   <% post.comments.last(5).each do |comment| %>
-    <p class="card-text m-0"><%= link_to comment.user, class: "a-decoration-none", data: {turbo_frame: "_top"} do %><span class="fw-bold me-2"><%= comment.user.username %></span><% end %><%= comment.body %></p>
+    <p class="card-text m-0"><%= link_to comment.user, class: "a-decoration-none", data: {turbo: false} do %><span class="fw-bold me-2"><%= comment.user.username %></span><% end %><%= comment.body %></p>
   <% end %>
 <% end %>
   <div class="modal fade" id="post<%= post.id %>_commentsModal" tabindex="-1" aria-labelledby="post<%= post.id %>_commentsModalLabel" aria-hidden="true">


### PR DESCRIPTION
Add follow state controls to post likers modal and comments modal disabling turbo on follow state controls to navigate outside of frame to send requests and redirect.